### PR TITLE
Add verbatim and embed engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ _book/*
 _bookdown_files/*
 packages.bib
 *-tikzDictionary
-css/box.css
 latex/blackbox.tex
 latex/infobox.tex
 

--- a/05-formatting.Rmd
+++ b/05-formatting.Rmd
@@ -205,32 +205,79 @@ The chunk option `fig.align`\index{chunk option!fig.align} specifies the alignme
 
 Typically we write code chunks and inline expressions that we want to be parsed and evaluated by **knitr**. However, if you are trying to write a tutorial on using **knitr**, you may need to generate a verbatim code chunk or inline expression that is _not_ parsed by **knitr**, and we want to display the content of the chunk header. 
 
-Unfortunately, we cannot wrap the code chunk in another layer of backticks, but instead we must make the code chunk invalid within the source code by inserting `` `r knitr::inline_expr("''")` ``\index{knitr!inline\_expr()} in the chunk header. This will be evaluated as an inline expression to _an empty string_ by **knitr**. For this example, the following "code chunk" in the source document:
+The `verbatim` engine will take any type of R Markdown valid content and output it as-is in the resulting document. By adding one more backtick in the upper layer than the inside content, a whole code chunk including the chunk header can be included. 
 
-````{r echo = FALSE, comment = NA}
-cat("```{r, eval=TRUE}`r ''`
+`````{verbatim}
+````{verbatim}
+```{r, eval=TRUE}
 1 + 1
-```")
+```
 ````
+`````
 
-will be rendered as:
+will be rendered as: 
 
-````
-```{r, eval=TRUE}`r ''`
+````{verbatim}
+```{r, eval=TRUE}
 1 + 1
 ```
 ````
 
-in the output. The inline expression is gone because it is substituted by an empty string. However, that is only the first step. To show something verbatim in the output, the syntax in Markdown is to wrap it in a code block (indent by four spaces or use backtick fences). This will be the actual source if you want to see the output above:
+in the output. You have to use at least N+1 backticks to wrap up N backticks, so four backticks here for the chunk header with the `verbatim` engine. 
 
-```{r echo = FALSE, comment = NA}
-cat("````
-```{r, eval=TRUE}`r ''`
+The content of the chunk will be placed in a fenced code block with class `default`, meaning not specific highlighting applied. You can set the `lang` chunk option to use a different language. For example, 
+
+`````{verbatim}
+````{verbatim, lang = "markdown"}
+We can output arbitrary content **verbatim**.
+
+```{r}
 1 + 1
-```\n````")
 ```
 
-Why four backticks? That is because you have to use at least N+1 backticks to wrap up N backticks.
+The content can contain inline code like
+`r pi * 5^2`, too.
+````
+`````
+
+will result in the markdown source file as 
+
+`````{verbatim, lang = "markdown"}
+````markdown
+We can output arbitrary content **verbatim**.
+
+```{r}
+1 + 1
+```
+
+The content can contain inline code like
+`r pi * 5^2`, too.
+````
+`````
+
+which will apply highlighting for markdown language on the code chunk in the output.
+
+If the content you want to include verbatim is already in a file, you can use the `embed` engine instead. Here is an example of the CSS we are using to create boxes in this book: 
+
+```{embed, file = "css/box.css"}
+```
+
+The syntax for the above inclusion in our Rmd source file is 
+
+````{verbatim, lang = "markdown"}
+```{embed, file = "css/box.css"}
+```
+````
+
+Another syntax for it is to pass the file as chunk body: 
+
+````{verbatim, lang = "markdown"}
+```{embed}
+"css/box.css"
+```
+````
+
+The `embed` engine is based on the `verbatim` engine. By default, the `lang` option is set based on the extension of the file you include. It can be modified using `lang` directly as chunk option. 
 
 ### Show a verbatim inline expression
 

--- a/05-formatting.Rmd
+++ b/05-formatting.Rmd
@@ -205,7 +205,7 @@ The chunk option `fig.align`\index{chunk option!fig.align} specifies the alignme
 
 Typically we write code chunks and inline expressions that we want to be parsed and evaluated by **knitr**. However, if you are trying to write a tutorial on using **knitr**, you may need to generate a verbatim code chunk or inline expression that is _not_ parsed by **knitr**, and we want to display the content of the chunk header. 
 
-The `verbatim` engine will take any type of R Markdown valid content and output it as-is in the resulting document. By adding one more backtick in the upper layer than the inside content, a whole code chunk including the chunk header can be included. 
+The `verbatim` engine can take any R Markdown content and output it as-is in the resulting document. By using more backticks on the outer fences than the backticks in the inner content, a whole code chunk including the chunk header can be included in a `verbatim` chunk. For example,
 
 `````{verbatim}
 ````{verbatim}
@@ -223,9 +223,9 @@ will be rendered as:
 ```
 ````
 
-in the output. You have to use at least N+1 backticks to wrap up N backticks, so four backticks here for the chunk header with the `verbatim` engine. 
+in the output. You have to use at least `N+1` backticks to wrap up `N` backticks. We are using four backticks here for the `verbatim` chunk because the inner chunk header contains three backticks.
 
-The content of the chunk will be placed in a fenced code block with class `default`, meaning not specific highlighting applied. You can set the `lang` chunk option to use a different language. For example, 
+The content of the `verbatim` chunk will be placed in a fenced code block with the class `default`, meaning no syntax highlighting will be applied. You can set the `lang` chunk option to use a different syntax highlighting language name. For example, 
 
 `````{verbatim}
 ````{verbatim, lang = "markdown"}
@@ -240,7 +240,7 @@ The content can contain inline code like
 ````
 `````
 
-will result in the markdown source file as 
+will result in the Markdown source file as 
 
 `````{verbatim, lang = "markdown"}
 ````markdown
@@ -255,9 +255,9 @@ The content can contain inline code like
 ````
 `````
 
-which will apply highlighting for markdown language on the code chunk in the output.
+The verbatim content will be syntax highlighted using the `markdown` language in the output.
 
-If the content you want to include verbatim is already in a file, you can use the `embed` engine instead. Here is an example of the CSS we are using to create boxes in this book: 
+If the content you want to include verbatim is in a file, you can use the `embed` engine instead. Here is an example of the CSS code from Section \@ref(block-shaded):
 
 ```{embed, file = "css/box.css"}
 ```

--- a/09-multiformat.Rmd
+++ b/09-multiformat.Rmd
@@ -231,17 +231,7 @@ First, we show how to include content in a shaded box. The box has a black backg
 
 For HTML output, we define these rules in a CSS file. If you are unfamiliar with CSS\index{CSS}, there are plenty of free online tutorials, e.g., https://www.w3schools.com/css/.
 
-```{cat, class.source='css', engine.opts=list(file = 'css/box.css')}
-.blackbox {
-  padding: 1em;
-  background: black;
-  color: white;
-  border: 2px solid orange;
-  border-radius: 10px;
-}
-.center {
-  text-align: center;
-}
+```{embed, file = 'css/box.css'}
 ```
 
 For LaTeX output, we create a new environment named `blackbox` and based on the LaTeX package **framed**\index{LaTeX package!framed}, with a black background and white text:

--- a/css/box.css
+++ b/css/box.css
@@ -1,0 +1,10 @@
+.blackbox {
+  padding: 1em;
+  background: black;
+  color: white;
+  border: 2px solid orange;
+  border-radius: 10px;
+}
+.center {
+  text-align: center;
+}


### PR DESCRIPTION
This replace the part about verbatim content using ``` `r ''` ```

Two questions: 

* Do we need to mention a minimal knitr version for this to work somehow ? I don't recall we did that for other feature so I was not sure
* Do we still want to mention the old syntax ? I would say it is not recommended anymore so probably no

closes #360