### PR TITLE
Use multi-line string to support multiple statements in R functions

### DIFF
--- a/17-workflow.Rmd
+++ b/17-workflow.Rmd
@@ -187,11 +187,12 @@ There may be situations in which we want to customize how the document is render
 
 It is possible to control the behavior of the `Knit` button by providing the `knit` field within the YAML frontmatter of your document. The field takes a function with the main argument `input` (the path to the input Rmd document) and other arguments that are currently ignored. You can either write the source code of the function directly in the `knit` field, or put the function elsewhere (e.g., in an R package) and call the function in the `knit` field. If you routinely need the custom `knit` function, we would recommend that you put it in a package, instead of repeating its source code in every single R Markdown document.
 
-If you store the code directly within YAML, you must wrap the entire function in parentheses. If the source code has multiple lines, you have to indent all lines (except the first line) by at least two spaces. For example, if we want the output filename to include the date on which it is rendered, we could use the following YAML  code\index{YAML!knit} in the Rmd document header:
+If you store the code directly within YAML, you must wrap the entire function in parentheses. If the source code has multiple lines, you have to indent the first line by exactly two spaces and all other lines by at least two spaces. For example, if we want the output filename to include the date on which it is rendered, we could use the following YAML  code\index{YAML!knit} in the Rmd document header:
 
 ```yaml
 ---
-knit: (function(input, ...) {
+knit: |
+  (function(input, ...) {
     rmarkdown::render(
       input,
       output_file = paste0(


### PR DESCRIPTION
This PR proposes to use literal style multi-line string in YAML to support seamless formatting of R functions defined in the `knit` field and avoid possible confusions from indentation details.

Specifically, the current code example for customizing the knit button behavior works but does not work for any non-trivial R functions containing multiple statements. For example, let's add a `print(input)` call before the `rmarkdown::render` call. Using the current approach:

```yaml
knit: (function(input, ...) {
    print(input)
    rmarkdown::render(
      input,
      output_file = paste0(
      xfun::sans_ext(input), '-', Sys.Date(), '.html'
    ),
    envir = globalenv()
    )
  })
```

The function will be parsed as:

```text
[1] "(function(input, ...) { print(input) rmarkdown::render( input, output_file = paste0( xfun::sans_ext(input), '-', Sys.Date(), '.html' ), envir = globalenv() ) })"
```

This does not execute:

```text
Error: unexpected symbol in "(function(input, ...) { invisible(system(paste0('(function(input, ...) { print(input) rmarkdown::render( input, output_file = paste0( xfun::sans_ext(input), '-', Sys.Date(), '.html"
Execution halted
```

A workaround is adding `;` after the first statement, which is non-idiomatic.

Instead, if we write

```yaml
knit: |
  (function(input, ...) {
    print(input)
    rmarkdown::render(
      input,
      output_file = paste0(
      xfun::sans_ext(input), '-', Sys.Date(), '.html'
    ),
    envir = globalenv()
    )
  })
```

This will be parsed as:

```text
[1] "(function(input, ...) {\n  print(input)\n  rmarkdown::render(\n    input,\n    output_file = paste0(\n    xfun::sans_ext(input), '-', Sys.Date(), '.html'\n  ),\n  envir = globalenv()\n  )\n})"
```

which can be correctly executed.

In reality, users can write the R function separately, copy and paste it here, and simply add two spaces before each line.